### PR TITLE
docs: documentar API de autenticación m1-01

### DIFF
--- a/src/main/java/com/acme/vocatio/controller/AuthController.java
+++ b/src/main/java/com/acme/vocatio/controller/AuthController.java
@@ -4,6 +4,12 @@ import com.acme.vocatio.dto.auth.AuthResponse;
 import com.acme.vocatio.dto.auth.LoginRequest;
 import com.acme.vocatio.dto.auth.RegisterRequest;
 import com.acme.vocatio.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,17 +22,46 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
+@Tag(name = "Autenticación", description = "Endpoints para registro y acceso de usuarios")
 public class AuthController {
 
     private final AuthService authService;
 
     @PostMapping("/register")
+    @Operation(
+            summary = "Registro de un nuevo usuario",
+            description = "Crea una cuenta con email y contraseña válidos. Si la opción **Recordarme** está activa,"
+                    + " se emitirá también un refresh token para persistir la sesión."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Registro exitoso",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AuthResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Datos de registro inválidos",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "409", description = "El email ya está registrado",
+                    content = @Content(mediaType = "application/json"))
+    })
     public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
         AuthResponse response = authService.register(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PostMapping("/login")
+    @Operation(
+            summary = "Inicio de sesión",
+            description = "Autentica a un usuario existente. Cuando se marca **Recordarme** el servicio"
+                    + " retornará un refresh token adicional para mantener la sesión activa."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Login exitoso",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = AuthResponse.class))),
+            @ApiResponse(responseCode = "400", description = "Datos de acceso inválidos",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "401", description = "Credenciales inválidas",
+                    content = @Content(mediaType = "application/json"))
+    })
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
         AuthResponse response = authService.login(request);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/acme/vocatio/dto/auth/AuthResponse.java
+++ b/src/main/java/com/acme/vocatio/dto/auth/AuthResponse.java
@@ -1,18 +1,34 @@
 package com.acme.vocatio.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 
+@Schema(name = "AuthResponse", description = "Respuesta estándar para el registro e inicio de sesión")
 public record AuthResponse(
+        @Schema(description = "Mensaje contextual del proceso de autenticación", example = "Registro exitoso")
         String message,
+        @Schema(description = "Datos mínimos del usuario autenticado")
         UserSummary user,
+        @Schema(description = "Tokens emitidos para manejar la sesión del usuario")
         TokenBundle tokens) {
 
-    public record UserSummary(Long id, String email) {}
+    @Schema(name = "AuthResponse.UserSummary", description = "Información básica del usuario autenticado")
+    public record UserSummary(
+            @Schema(description = "Identificador interno del usuario", example = "42") Long id,
+            @Schema(description = "Correo electrónico del usuario", example = "ada.lovelace@example.com") String email) {
+    }
 
+    @Schema(name = "AuthResponse.TokenBundle", description = "Tokens devueltos al autenticarse")
     public record TokenBundle(
+            @Schema(description = "Tipo del token de acceso", example = "Bearer")
             String tokenType,
+            @Schema(description = "JWT de acceso", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
             String accessToken,
+            @Schema(description = "Fecha de expiración del token de acceso", example = "2024-07-12T21:45:00Z")
             Instant accessTokenExpiresAt,
+            @Schema(description = "Refresh token emitido cuando corresponde", example = "def50200c9b2...")
             String refreshToken,
-            Instant refreshTokenExpiresAt) {}
+            @Schema(description = "Fecha de expiración del refresh token", example = "2024-07-26T21:45:00Z")
+            Instant refreshTokenExpiresAt) {
+    }
 }

--- a/src/main/java/com/acme/vocatio/dto/auth/LoginRequest.java
+++ b/src/main/java/com/acme/vocatio/dto/auth/LoginRequest.java
@@ -1,13 +1,17 @@
 package com.acme.vocatio.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
+        @Schema(description = "Correo electrónico registrado", example = "ada.lovelace@example.com")
         @NotBlank(message = "El email es obligatorio")
                 @Email(message = "Ingresa un email válido")
                 String email,
+        @Schema(description = "Contraseña asociada a la cuenta", example = "Cl4veSegura")
         @NotBlank(message = "La contraseña es obligatoria") String password,
+        @Schema(description = "Solicita mantener la sesión activa mediante refresh tokens", example = "true")
         Boolean rememberMe) {
 
     //public boolean rememberMe() {

--- a/src/main/java/com/acme/vocatio/dto/auth/RegisterRequest.java
+++ b/src/main/java/com/acme/vocatio/dto/auth/RegisterRequest.java
@@ -1,19 +1,23 @@
 package com.acme.vocatio.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record RegisterRequest(
+        @Schema(description = "Correo electrónico único del usuario", example = "ada.lovelace@example.com")
         @NotBlank(message = "El email es obligatorio")
                 @Email(message = "Ingresa un email válido")
                 String email,
+        @Schema(description = "Contraseña que cumple con las políticas de seguridad", example = "Cl4veSegura")
         @NotBlank(message = "La contraseña es obligatoria")
                 @Size(min = 8, message = "La contraseña debe tener al menos 8 caracteres")
                 @Pattern(regexp = ".*[A-Z].*", message = "La contraseña debe incluir al menos una letra mayúscula")
                 @Pattern(regexp = ".*[0-9].*", message = "La contraseña debe incluir al menos un número")
                 String password,
+        @Schema(description = "Indica si se debe mantener la sesión abierta mediante refresh tokens", example = "true")
         boolean rememberMe) {
 
     //public boolean rememberMe() {


### PR DESCRIPTION
## Summary
- documentar los endpoints /auth/register y /auth/login con descripciones y respuestas alineadas al caso de uso m1-01
- enriquecer los DTOs de autenticación con metadatos de OpenAPI para ejemplos y descripciones consistentes

## Testing
- ./mvnw -q -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e57a831e18832ea5e27eb223f912ee

## Summary by Sourcery

Add comprehensive OpenAPI documentation to the authentication endpoints and related DTOs

Documentation:
- Annotate AuthController with Swagger tag, operations, and detailed response schemas for register and login endpoints
- Enrich AuthResponse, UserSummary, TokenBundle, LoginRequest, and RegisterRequest with @Schema metadata including descriptions and examples