### PR TITLE
Implement personal data update and password change endpoints

### DIFF
--- a/src/main/java/com/acme/vocatio/config/SecurityConfig.java
+++ b/src/main/java/com/acme/vocatio/config/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
                         // ✅ Públicos SIN /api/v1: MvcRequestMatcher los adapta
                         .requestMatchers(
                                 mvc.pattern("/"),
-                                mvc.pattern("/auth/**"),
+                                mvc.pattern("/auth/login"),
+                                mvc.pattern("/auth/register"),
                                 mvc.pattern("/v3/api-docs/**"),
                                 mvc.pattern("/swagger-ui/**"),
                                 mvc.pattern("/swagger-ui.html"),

--- a/src/main/java/com/acme/vocatio/controller/AuthController.java
+++ b/src/main/java/com/acme/vocatio/controller/AuthController.java
@@ -1,13 +1,17 @@
 package com.acme.vocatio.controller;
 
 import com.acme.vocatio.dto.auth.AuthResponse;
+import com.acme.vocatio.dto.auth.ChangePasswordRequest;
+import com.acme.vocatio.dto.auth.ChangePasswordResponse;
 import com.acme.vocatio.dto.auth.LoginRequest;
 import com.acme.vocatio.dto.auth.RegisterRequest;
+import com.acme.vocatio.security.UserPrincipal;
 import com.acme.vocatio.service.AuthService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,5 +34,13 @@ public class AuthController {
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
         AuthResponse response = authService.login(request);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/change-password")
+    public ResponseEntity<ChangePasswordResponse> changePassword(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @Valid @RequestBody ChangePasswordRequest request) {
+        authService.changePassword(principal.getUser().getId(), request);
+        return ResponseEntity.ok(new ChangePasswordResponse("Contraseña actualizada. Inicia sesión nuevamente.", true));
     }
 }

--- a/src/main/java/com/acme/vocatio/controller/UserProfileController.java
+++ b/src/main/java/com/acme/vocatio/controller/UserProfileController.java
@@ -1,5 +1,7 @@
 package com.acme.vocatio.controller;
 
+import com.acme.vocatio.dto.profile.PersonalDataUpdateRequest;
+import com.acme.vocatio.dto.profile.PersonalDataUpdateResponse;
 import com.acme.vocatio.dto.profile.ProfileDto;
 import com.acme.vocatio.dto.profile.ProfileUpdateRequest;
 import com.acme.vocatio.dto.profile.ProfileUpdateResponse;
@@ -10,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,5 +38,13 @@ public class UserProfileController {
             @AuthenticationPrincipal UserPrincipal principal, @Valid @RequestBody ProfileUpdateRequest request) {
         ProfileDto updatedProfile = userProfileService.updateCurrentUserProfile(principal.getUser().getId(), request);
         return ResponseEntity.ok(new ProfileUpdateResponse("Perfil actualizado", updatedProfile));
+    }
+
+    /** Actualiza nombre y preferencias no sensibles. */
+    @PatchMapping
+    public ResponseEntity<PersonalDataUpdateResponse> updatePersonalData(
+            @AuthenticationPrincipal UserPrincipal principal, @Valid @RequestBody PersonalDataUpdateRequest request) {
+        ProfileDto updatedProfile = userProfileService.updatePersonalData(principal.getUser().getId(), request);
+        return ResponseEntity.ok(new PersonalDataUpdateResponse("Datos personales actualizados", updatedProfile));
     }
 }

--- a/src/main/java/com/acme/vocatio/dto/auth/ChangePasswordRequest.java
+++ b/src/main/java/com/acme/vocatio/dto/auth/ChangePasswordRequest.java
@@ -1,0 +1,14 @@
+package com.acme.vocatio.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/** Solicitud para actualizar la contraseña actual. */
+public record ChangePasswordRequest(
+        @NotBlank(message = "La contraseña actual es obligatoria") String currentPassword,
+        @NotBlank(message = "La nueva contraseña es obligatoria")
+                @Size(min = 8, message = "La contraseña debe tener al menos 8 caracteres")
+                @Pattern(regexp = ".*[A-Z].*", message = "La contraseña debe incluir al menos una letra mayúscula")
+                @Pattern(regexp = ".*[0-9].*", message = "La contraseña debe incluir al menos un número")
+                String newPassword) {}

--- a/src/main/java/com/acme/vocatio/dto/auth/ChangePasswordResponse.java
+++ b/src/main/java/com/acme/vocatio/dto/auth/ChangePasswordResponse.java
@@ -1,0 +1,4 @@
+package com.acme.vocatio.dto.auth;
+
+/** Respuesta al cambiar la contraseña. */
+public record ChangePasswordResponse(String message, boolean requireRelogin) {}

--- a/src/main/java/com/acme/vocatio/dto/profile/PersonalDataUpdateRequest.java
+++ b/src/main/java/com/acme/vocatio/dto/profile/PersonalDataUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.acme.vocatio.dto.profile;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.Map;
+
+/** Payload para actualizar nombre y preferencias públicas. */
+public record PersonalDataUpdateRequest(
+        @NotBlank(message = "El nombre es obligatorio")
+                @Size(max = 100, message = "El nombre debe tener máximo 100 caracteres")
+                String name,
+        Map<@NotBlank(message = "La clave de preferencia no puede estar vacía") String,
+                @NotNull(message = "El valor de la preferencia es obligatorio") Boolean> preferences) {
+}

--- a/src/main/java/com/acme/vocatio/dto/profile/PersonalDataUpdateResponse.java
+++ b/src/main/java/com/acme/vocatio/dto/profile/PersonalDataUpdateResponse.java
@@ -1,0 +1,4 @@
+package com.acme.vocatio.dto.profile;
+
+/** Respuesta al actualizar los datos personales. */
+public record PersonalDataUpdateResponse(String message, ProfileDto profile) {}

--- a/src/main/java/com/acme/vocatio/dto/profile/ProfileDto.java
+++ b/src/main/java/com/acme/vocatio/dto/profile/ProfileDto.java
@@ -1,12 +1,15 @@
 package com.acme.vocatio.dto.profile;
 
 import java.util.List;
+import java.util.Map;
 
 /** Vista consolidada del perfil personal. */
 public record ProfileDto(
         Long id,
         String email,
+        String name,
         Integer age,
         String grade,
         String gradeLabel,
-        List<String> interests) {}
+        List<String> interests,
+        Map<String, Boolean> preferences) {}

--- a/src/main/java/com/acme/vocatio/exception/InvalidCurrentPasswordException.java
+++ b/src/main/java/com/acme/vocatio/exception/InvalidCurrentPasswordException.java
@@ -1,0 +1,8 @@
+package com.acme.vocatio.exception;
+
+/** Se lanza cuando la contraseña actual no coincide con la registrada. */
+public class InvalidCurrentPasswordException extends RuntimeException {
+    public InvalidCurrentPasswordException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/acme/vocatio/exception/InvalidPasswordChangeException.java
+++ b/src/main/java/com/acme/vocatio/exception/InvalidPasswordChangeException.java
@@ -1,0 +1,8 @@
+package com.acme.vocatio.exception;
+
+/** Se lanza cuando la nueva contraseña no cumple la política establecida. */
+public class InvalidPasswordChangeException extends RuntimeException {
+    public InvalidPasswordChangeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/acme/vocatio/exception/InvalidPersonalDataException.java
+++ b/src/main/java/com/acme/vocatio/exception/InvalidPersonalDataException.java
@@ -1,0 +1,8 @@
+package com.acme.vocatio.exception;
+
+/** Se lanza cuando los datos personales no cumplen los criterios permitidos. */
+public class InvalidPersonalDataException extends RuntimeException {
+    public InvalidPersonalDataException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/acme/vocatio/exception/PasswordChangeRateLimitException.java
+++ b/src/main/java/com/acme/vocatio/exception/PasswordChangeRateLimitException.java
@@ -1,0 +1,15 @@
+package com.acme.vocatio.exception;
+
+/** Indica que se alcanzó el límite de intentos para cambiar la contraseña. */
+public class PasswordChangeRateLimitException extends RuntimeException {
+    private final long retryAfterSeconds;
+
+    public PasswordChangeRateLimitException(String message, long retryAfterSeconds) {
+        super(message);
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+
+    public long retryAfterSeconds() {
+        return retryAfterSeconds;
+    }
+}

--- a/src/main/java/com/acme/vocatio/model/Profile.java
+++ b/src/main/java/com/acme/vocatio/model/Profile.java
@@ -41,4 +41,7 @@ public class Profile {
 
     @Column(name = "personal_interests", columnDefinition = "jsonb")
     private String personalInterests;
+
+    @Column(name = "public_preferences", columnDefinition = "jsonb")
+    private String publicPreferences;
 }

--- a/src/main/java/com/acme/vocatio/service/PasswordChangeRateLimiter.java
+++ b/src/main/java/com/acme/vocatio/service/PasswordChangeRateLimiter.java
@@ -1,0 +1,82 @@
+package com.acme.vocatio.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+/**
+ * Controla los intentos fallidos de cambio de contraseña para evitar ataques de fuerza bruta.
+ */
+@Component
+public class PasswordChangeRateLimiter {
+
+    private static final int MAX_ATTEMPTS = 5;
+    private static final Duration LOCK_DURATION = Duration.ofMinutes(15);
+
+    private final Map<Long, Attempt> attempts = new ConcurrentHashMap<>();
+
+    public boolean isBlocked(Long userId) {
+        Attempt attempt = attempts.get(userId);
+        if (attempt == null || attempt.blockedUntil == null) {
+            return false;
+        }
+
+        Instant now = Instant.now();
+        if (now.isAfter(attempt.blockedUntil)) {
+            attempts.remove(userId);
+            return false;
+        }
+        return true;
+    }
+
+    public Duration getRemainingLockDuration(Long userId) {
+        Attempt attempt = attempts.get(userId);
+        if (attempt == null || attempt.blockedUntil == null) {
+            return Duration.ZERO;
+        }
+
+        Instant now = Instant.now();
+        if (now.isAfter(attempt.blockedUntil)) {
+            attempts.remove(userId);
+            return Duration.ZERO;
+        }
+        return Duration.between(now, attempt.blockedUntil);
+    }
+
+    public void recordFailure(Long userId) {
+        Instant now = Instant.now();
+        attempts.compute(userId, (id, current) -> {
+            if (current == null) {
+                Attempt attempt = new Attempt();
+                attempt.failures = 1;
+                return attempt;
+            }
+
+            if (current.blockedUntil != null) {
+                if (now.isAfter(current.blockedUntil)) {
+                    current.blockedUntil = null;
+                    current.failures = 1;
+                }
+                return current;
+            }
+
+            current.failures += 1;
+            if (current.failures >= MAX_ATTEMPTS) {
+                current.failures = 0;
+                current.blockedUntil = now.plus(LOCK_DURATION);
+            }
+            return current;
+        });
+    }
+
+    public void reset(Long userId) {
+        attempts.remove(userId);
+    }
+
+    private static final class Attempt {
+        int failures;
+        Instant blockedUntil;
+    }
+}

--- a/src/main/java/com/acme/vocatio/service/UserProfileService.java
+++ b/src/main/java/com/acme/vocatio/service/UserProfileService.java
@@ -1,7 +1,9 @@
 package com.acme.vocatio.service;
 
+import com.acme.vocatio.dto.profile.PersonalDataUpdateRequest;
 import com.acme.vocatio.dto.profile.ProfileDto;
 import com.acme.vocatio.dto.profile.ProfileUpdateRequest;
+import com.acme.vocatio.exception.InvalidPersonalDataException;
 import com.acme.vocatio.exception.UserNotFoundException;
 import com.acme.vocatio.model.AcademicGrade;
 import com.acme.vocatio.model.Profile;
@@ -26,6 +28,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserProfileService {
 
     private static final TypeReference<List<String>> STRING_LIST_TYPE = new TypeReference<>() {};
+    private static final TypeReference<Map<String, Boolean>> STRING_BOOLEAN_MAP_TYPE = new TypeReference<>() {};
 
     private final UserRepository userRepository;
     private final ProfileRepository profileRepository;
@@ -36,6 +39,35 @@ public class UserProfileService {
         User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
         Profile profile = profileRepository.findById(userId).orElse(null);
         return toDto(user, profile);
+    }
+
+    /** Actualiza nombre y preferencias públicas. */
+    @Transactional
+    public ProfileDto updatePersonalData(Long userId, PersonalDataUpdateRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException(userId));
+
+        Profile profile = profileRepository
+                .findById(userId)
+                .orElseGet(() -> {
+                    Profile newProfile = new Profile();
+                    newProfile.setId(userId);
+                    newProfile.setUser(user);
+                    return newProfile;
+                });
+
+        profile.setUser(user);
+        user.setProfile(profile);
+
+        String normalizedName = request.name().trim();
+        profile.setName(normalizedName);
+
+        if (request.preferences() != null) {
+            Map<String, Boolean> normalizedPreferences = normalizePreferences(request.preferences());
+            profile.setPublicPreferences(writePreferences(normalizedPreferences));
+        }
+
+        Profile saved = profileRepository.save(profile);
+        return toDto(user, saved);
     }
 
     /** Guarda los cambios de edad, grado e intereses. */
@@ -111,16 +143,21 @@ public class UserProfileService {
     /** Crea el DTO usando los datos existentes. */
     private ProfileDto toDto(User user, Profile profile) {
         List<String> interests = profile == null ? List.of() : readInterests(profile.getPersonalInterests());
-        return toDto(user, profile, interests);
+        Map<String, Boolean> preferences =
+                profile == null ? Map.of() : readPreferences(profile.getPublicPreferences());
+        return toDto(user, profile, interests, preferences);
     }
 
     /** Ajusta el DTO con edad, grado e intereses. */
-    private ProfileDto toDto(User user, Profile profile, List<String> interests) {
+    private ProfileDto toDto(
+            User user, Profile profile, List<String> interests, Map<String, Boolean> preferences) {
         Integer age = null;
         String gradeCode = null;
         String gradeLabel = null;
+        String name = null;
 
         if (profile != null) {
+            name = profile.getName();
             if (profile.getAge() != null) {
                 age = profile.getAge().intValue();
             }
@@ -131,7 +168,61 @@ public class UserProfileService {
         }
 
         List<String> safeInterests = interests == null ? List.of() : List.copyOf(interests);
+        Map<String, Boolean> safePreferences = preferences == null ? Map.of() : Map.copyOf(preferences);
 
-        return new ProfileDto(user.getId(), user.getEmail(), age, gradeCode, gradeLabel, safeInterests);
+        return new ProfileDto(user.getId(), user.getEmail(), name, age, gradeCode, gradeLabel, safeInterests, safePreferences);
+    }
+
+    private ProfileDto toDto(User user, Profile profile, List<String> interests) {
+        Map<String, Boolean> preferences =
+                profile == null ? Map.of() : readPreferences(profile.getPublicPreferences());
+        return toDto(user, profile, interests, preferences);
+    }
+
+    private Map<String, Boolean> normalizePreferences(Map<String, Boolean> rawPreferences) {
+        Map<String, Boolean> normalized = new LinkedHashMap<>();
+        for (Map.Entry<String, Boolean> entry : rawPreferences.entrySet()) {
+            String key = entry.getKey();
+            if (key == null) {
+                continue;
+            }
+
+            String trimmedKey = key.trim();
+            if (trimmedKey.isEmpty()) {
+                continue;
+            }
+
+            Boolean value = entry.getValue();
+            if (value == null) {
+                throw new InvalidPersonalDataException(
+                        "El valor de la preferencia '" + trimmedKey + "' es obligatorio");
+            }
+
+            normalized.put(trimmedKey, value);
+        }
+        return Map.copyOf(normalized);
+    }
+
+    private String writePreferences(Map<String, Boolean> preferences) {
+        try {
+            return objectMapper.writeValueAsString(preferences);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("No fue posible guardar las preferencias públicas", ex);
+        }
+    }
+
+    private Map<String, Boolean> readPreferences(String preferencesJson) {
+        if (preferencesJson == null || preferencesJson.isBlank()) {
+            return Map.of();
+        }
+        try {
+            Map<String, Boolean> preferences = objectMapper.readValue(preferencesJson, STRING_BOOLEAN_MAP_TYPE);
+            Map<String, Boolean> sanitized = preferences.entrySet().stream()
+                    .filter(entry -> entry.getKey() != null && entry.getValue() != null)
+                    .collect(LinkedHashMap::new, (map, entry) -> map.put(entry.getKey(), entry.getValue()), Map::putAll);
+            return Map.copyOf(sanitized);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("No fue posible leer las preferencias almacenadas", ex);
+        }
     }
 }

--- a/src/main/java/com/acme/vocatio/web/GlobalExceptionHandler.java
+++ b/src/main/java/com/acme/vocatio/web/GlobalExceptionHandler.java
@@ -2,6 +2,10 @@ package com.acme.vocatio.web;
 
 import com.acme.vocatio.exception.DuplicateEmailException;
 import com.acme.vocatio.exception.InvalidCredentialsException;
+import com.acme.vocatio.exception.InvalidCurrentPasswordException;
+import com.acme.vocatio.exception.InvalidPersonalDataException;
+import com.acme.vocatio.exception.InvalidPasswordChangeException;
+import com.acme.vocatio.exception.PasswordChangeRateLimitException;
 import com.acme.vocatio.exception.UserNotFoundException;
 import jakarta.validation.ConstraintViolationException;
 import java.util.HashMap;
@@ -65,6 +69,39 @@ public class GlobalExceptionHandler {
         Map<String, Object> body = new HashMap<>();
         body.put("message", ex.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(body);
+    }
+
+    /** Contraseña actual incorrecta al intentar actualizarla. */
+    @ExceptionHandler(InvalidCurrentPasswordException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidCurrentPassword(InvalidCurrentPasswordException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    /** Indica errores al actualizar datos personales. */
+    @ExceptionHandler(InvalidPersonalDataException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidPersonalData(InvalidPersonalDataException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", ex.getMessage());
+        return ResponseEntity.badRequest().body(body);
+    }
+
+    /** Error cuando la contraseña nueva no cumple la política. */
+    @ExceptionHandler(InvalidPasswordChangeException.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidPasswordChange(InvalidPasswordChangeException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", ex.getMessage());
+        return ResponseEntity.badRequest().body(body);
+    }
+
+    /** Indica que se alcanzó el límite de intentos de cambio de contraseña. */
+    @ExceptionHandler(PasswordChangeRateLimitException.class)
+    public ResponseEntity<Map<String, Object>> handlePasswordChangeRateLimit(PasswordChangeRateLimitException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", ex.getMessage());
+        body.put("retryAfterSeconds", ex.retryAfterSeconds());
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(body);
     }
 
     /** Avisa cuando no se encontró al usuario. */


### PR DESCRIPTION
## Summary
- add a PATCH /users/me endpoint to update the authenticated user name and public preferences while extending profile DTOs
- implement /auth/change-password with password policy validation, token revocation and rate limiting after repeated failures
- restrict the security whitelist to login/register and surface clear API errors for personal data and password issues

## Testing
- ./mvnw -q test *(fails: PostgreSQL datasource URL not configured in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e57acbb49c832e8279383b2925bcf5