### PR TITLE
docs: add OpenAPI documentation for auth endpoints

### DIFF
--- a/src/main/java/com/acme/vocatio/controller/AuthController.java
+++ b/src/main/java/com/acme/vocatio/controller/AuthController.java
@@ -4,6 +4,11 @@ import com.acme.vocatio.dto.auth.AuthResponse;
 import com.acme.vocatio.dto.auth.LoginRequest;
 import com.acme.vocatio.dto.auth.RegisterRequest;
 import com.acme.vocatio.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,17 +21,68 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
+@Tag(name = "Autenticación", description = "Endpoints para registro e inicio de sesión de personas usuarias")
 public class AuthController {
 
     private final AuthService authService;
 
     @PostMapping("/register")
+    @Operation(
+            summary = "Registra una nueva cuenta",
+            description = "Crea una cuenta con email y contraseña válidos. Si el registro es exitoso se inicia sesión de forma automática",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "201",
+                            description = "Registro exitoso",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = AuthResponse.class))),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Email o contraseña inválidos",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(
+                                            description = "Detalle de reglas de validación incumplidas",
+                                            example = "{\n  \"message\": \"Revise los datos enviados\",\n  \"errors\": {\n    \"email\": [\"Ingresa un email válido\"],\n    \"password\": [\"La contraseña debe tener al menos 8 caracteres\"]\n  }\n}"))),
+                    @ApiResponse(
+                            responseCode = "409",
+                            description = "Email ya registrado",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(
+                                            description = "Mensaje y sugerencias cuando el email ya está en uso",
+                                            example = "{\n  \"message\": \"El email ya está registrado\",\n  \"suggestions\": [\"Inicia sesión con tu cuenta\", \"Recupera tu contraseña si la olvidaste\"]\n}")))
+            })
     public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
         AuthResponse response = authService.register(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @PostMapping("/login")
+    @Operation(
+            summary = "Inicia sesión con una cuenta existente",
+            description = "Autentica a la persona usuaria usando email y contraseña. Entrega tokens de acceso y refresh",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Autenticación exitosa",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = AuthResponse.class))),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "Email o contraseña faltante o inválida",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(
+                                            description = "Detalle de validaciones fallidas",
+                                            example = "{\n  \"message\": \"Revise los datos enviados\",\n  \"errors\": {\n    \"email\": [\"Ingresa un email válido\"],\n    \"password\": [\"La contraseña es obligatoria\"]\n  }\n}"))),
+                    @ApiResponse(
+                            responseCode = "401",
+                            description = "Credenciales inválidas",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(
+                                            description = "Mensaje genérico cuando el email o la contraseña no coinciden",
+                                            example = "{\n  \"message\": \"Credenciales inválidas\"\n}")))
+            })
     public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
         AuthResponse response = authService.login(request);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/acme/vocatio/dto/auth/AuthResponse.java
+++ b/src/main/java/com/acme/vocatio/dto/auth/AuthResponse.java
@@ -1,18 +1,26 @@
 package com.acme.vocatio.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 
+@Schema(description = "Respuesta estándar para operaciones de autenticación")
 public record AuthResponse(
-        String message,
+        @Schema(example = "Registro exitoso") String message,
         UserSummary user,
         TokenBundle tokens) {
 
-    public record UserSummary(Long id, String email) {}
+    @Schema(description = "Resumen de la persona usuaria autenticada")
+    public record UserSummary(
+            @Schema(example = "42") Long id,
+            @Schema(example = "ada.lovelace@example.com") String email) {}
 
+    @Schema(description = "Tokens emitidos tras la autenticación")
     public record TokenBundle(
-            String tokenType,
-            String accessToken,
-            Instant accessTokenExpiresAt,
-            String refreshToken,
-            Instant refreshTokenExpiresAt) {}
+            @Schema(example = "Bearer") String tokenType,
+            @Schema(description = "JWT de acceso", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...") String accessToken,
+            @Schema(description = "Fecha de expiración del access token en ISO-8601", example = "2025-03-01T12:34:56Z")
+                    Instant accessTokenExpiresAt,
+            @Schema(description = "Token para renovar la sesión", example = "dXNlcjoxMjM0NTY=") String refreshToken,
+            @Schema(description = "Fecha de expiración del refresh token en ISO-8601", example = "2025-03-15T12:34:56Z")
+                    Instant refreshTokenExpiresAt) {}
 }

--- a/src/main/java/com/acme/vocatio/dto/auth/LoginRequest.java
+++ b/src/main/java/com/acme/vocatio/dto/auth/LoginRequest.java
@@ -1,14 +1,19 @@
 package com.acme.vocatio.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "Credenciales necesarias para iniciar sesión")
 public record LoginRequest(
-        @NotBlank(message = "El email es obligatorio")
+        @Schema(example = "ada.lovelace@example.com")
+                @NotBlank(message = "El email es obligatorio")
                 @Email(message = "Ingresa un email válido")
                 String email,
-        @NotBlank(message = "La contraseña es obligatoria") String password,
-        Boolean rememberMe) {
+        @Schema(example = "ClaveSegura1")
+                @NotBlank(message = "La contraseña es obligatoria") String password,
+        @Schema(description = "Recuerda la sesión si es verdadero", example = "true")
+                Boolean rememberMe) {
 
     //public boolean rememberMe() {
     //    return Boolean.TRUE.equals(rememberMe);

--- a/src/main/java/com/acme/vocatio/dto/auth/RegisterRequest.java
+++ b/src/main/java/com/acme/vocatio/dto/auth/RegisterRequest.java
@@ -1,20 +1,27 @@
 package com.acme.vocatio.dto.auth;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "Payload necesario para registrar una nueva cuenta")
 public record RegisterRequest(
-        @NotBlank(message = "El email es obligatorio")
+        @Schema(example = "ada.lovelace@example.com", description = "Correo electrónico válido y único")
+                @NotBlank(message = "El email es obligatorio")
                 @Email(message = "Ingresa un email válido")
                 String email,
-        @NotBlank(message = "La contraseña es obligatoria")
+        @Schema(example = "ClaveSegura1", description = "Contraseña que cumple con las políticas de seguridad")
+                @NotBlank(message = "La contraseña es obligatoria")
                 @Size(min = 8, message = "La contraseña debe tener al menos 8 caracteres")
                 @Pattern(regexp = ".*[A-Z].*", message = "La contraseña debe incluir al menos una letra mayúscula")
                 @Pattern(regexp = ".*[0-9].*", message = "La contraseña debe incluir al menos un número")
                 String password,
-        boolean rememberMe) {
+        @Schema(
+                description = "Indica si se debe recordar la sesión del usuario para extender la vigencia del refresh token",
+                example = "true")
+                boolean rememberMe) {
 
     //public boolean rememberMe() {
     //    return Boolean.TRUE.equals(rememberMe);


### PR DESCRIPTION
## Summary
- annotate the authentication controller with OpenAPI metadata that documents success and error scenarios for register and login
- enrich auth request and response DTOs with schema descriptions and examples to expose password policies and token details

## Testing
- ./mvnw -q -DskipTests compile

## Summary by Sourcery

Annotate the authentication controller and DTOs with OpenAPI annotations to fully document the register and login endpoints, including request/response schemas, examples, and error scenarios

Documentation:
- Add Swagger/OpenAPI tags and Operation annotations to AuthController for register and login endpoints
- Enrich RegisterRequest, LoginRequest, and AuthResponse DTOs with @Schema descriptions and examples to expose validation rules and token details